### PR TITLE
Lots of (likely bad) refactoring to get the app working in AWS Lambda

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,10 +1,10 @@
-// yle-tiksuttelija-slack-app
-// Antti Plathan 8 Feb 2021
-// antti.plathan@gmail.com
+'use strict'
 
 const { App, ExpressReceiver } = require('@slack/bolt');
 const awsServerlessExpress = require('aws-serverless-express');
-const sn = require('servicenow-rest-api');
+const axios = require('axios').default;
+//const awsServerlessExpressMiddleware = require('aws-serverless-express/middleware');
+//const sn = require('servicenow-rest-api');
 
 // Initialize your custom receiver
 const expressReceiver = new ExpressReceiver({
@@ -24,13 +24,43 @@ const app = new App({
 
 // Initialize your AWSServerlessExpress server using Bolt's ExpressReceiver
 const server = awsServerlessExpress.createServer(expressReceiver.app);
+// var event = req.apiGateway.event;
+// var context = req.apiGateway.context;
 
-// pitääkö tämäkin initialisoida expressReceiverillä?
-// Initialize ServiceNow
-const ServiceNow = new sn(process.env.TIKSU_INSTANCE, process.env.TIKSU_USERID, process.env.TIKSU_PASSWORD);
+// Getting the API Gateway event object
+//app.use(awsServerlessExpressMiddleware.eventContext());
+//app.get('/', (req, res) => {
+//  res.json(req.apiGateway.event);
+//})
 
-// Kuunnellaan /tiksu -läsykomentoa ja avatan käyttäjälle uusi modaali
-app.command('/tiksu', async ({ ack, body, client }) => {
+
+/*
+
+
+https://stackoverflow.com/questions/61001210/https-get-request-from-within-a-lambda-function-for-slack-bot
+
+
+
+*/
+
+// Middleware to enrich context object that is available to all listeners
+async function enrichContext({ payload, client, context, next }) {
+  // https://api.slack.com/methods/users.profile.get
+  const user = await client.users.profile.get({ user: user_id });
+  
+  context.email = user.profile.email;
+  context.real_name = user.profile.real_name;
+  context.tiksu_userid = process.env.TIKSU_USERID;
+  context.tiksu_password = process.env.TIKSU_PASSWORD;
+  context.tiksu_instance = process.env.TIKSU_INSTANCE;
+
+  // Pass control to the next middleware function
+  await next();
+}
+
+
+// Bolt method to handle incoming Slack command event. A new modal view is created as a response.
+app.command('/tiksu', enrichContext, async ({ ack, body, client, context }) => {
   await ack();
 
   try {
@@ -150,27 +180,28 @@ app.command('/tiksu', async ({ ack, body, client }) => {
 });
 
 
-// Handler for processing data sent from the new incident modal
+// Bolt method to handle incoming Slack view_submission events
 app.view('view-new-incident', async ({ ack, body, view, client }) => {
   await ack();
 
-  // Aloitetaan Tiksuun autentikoituminen mahdollisimman varhaisessa vaiheessa
-  try {
-    ServiceNow.Authenticate();
-    // Voiko tässäkin käyttää callback-funktiota? Tyyliin
-    // ServiceNow.Authenticate(res => { console.log(res) });
-  }
-  catch (error) {
-    console.error(error);
-  }
-
-  // Kerätään lomakkeella annetut tiedot
+  // Parse the 'view' payload to get user input from modal view's input blocks.
+  // View object is a dictionary consisting of modal's [block_id](s) and [action_id](s)
+  // Figuring out the data model can be a little trial and error, as the view payload's
+  // json may contain both simple key-value pairs, but also objects as the values.
   const user_id = body['user']['id'];
   const short_description = view['state']['values']['short_description']['short_description'].value;
   const description = view['state']['values']['description']['description'].value;
   const u_app_or_prod_unit = view['state']['values']['u_app_or_prod_unit']['u_app_or_prod_unit']['selected_option'].value;
   
   // Kysytään Slack API:lta käyttäjän profiilia ja sieltä sähköpostiosoite. Näitä tietoja ei saa suoraan eventin mukana
+  // Slack user profile data is privileged information, and is not passed freely with Slack events. For example,
+  // user ID is not 
+
+  // LUE TÄSTÄ LISÄÄ: https://slack.dev/bolt-js/concepts#listener-middleware
+  // Saattaa ratkaista sekä käyttäjän nimen / emailin hanskaamisen sekä env.variablet
+  // tosin env. variableissa pitää olla tarkkana, että ne pysyy suojattuina
+  
+  The users:read.email OAuth scope is now required to access the email field in user objects returned by the users.list and users.info web API methods.
   try {
     var user = await client.users.profile.get({ user: user_id });
     var user_email = user.profile.email;
@@ -206,101 +237,116 @@ app.view('view-new-incident', async ({ ack, body, view, client }) => {
     }
   } else {
       // Eli nyt käyttäjällä tiedetään olevan yle-osoite
-      try{
-        ServiceNow.createNewTask(newIncidentData, 'incident', res => {
-          var tiksu_response = res;
-          var sys_id = tiksu_response.sys_id;
-          var tiksu_id = tiksu_response.number;
-          var responseDescription = tiksu_response.short_description;
-          var tiksu_url = 'https://yletest.service-now.com/incident.do?sys_id=' + sys_id;
-          msg = 'Tiketin lähettäminen onnistui. Voit seurata tikettisi etenemistä Tiksussa: <' + tiksu_url + '|' + tiksu_id + '>';
+      try {
+        const options = {
+            url:'https://' + process.env.TIKSU_INSTANCE + '/api/now/table/incident?sysparm_input_display_value=true&sysparm_display_value=true',
+            method:'post',
+            headers:{
+                'Accept':'application/json',
+                'Content-Type':'application/json'
+            },
+            data:newIncidentData,
+            auth:{
+                username:process.env.TIKSU_USERID,
+                password:process.env.TIKSU_PASSWORD
+            }
+        };
+        // Tämä on varsinainen kutsu ServiceNowiin
+        var tiksu_res = await axios(options);
+        var res = tiksu_res.data.result;
+        console.log(res);
+
+        var tiksu_url = 'https://yletest.service-now.com/incident.do?sys_id=' + res.sys_id;
+        msg = 'Tiketin lähettäminen onnistui. Voit seurata tikettisi etenemistä Tiksussa: <' + tiksu_url + '|' + res.number + '>';
+
+        try {
+          await client.chat.postMessage({
+            channel: user_id,
+            text: msg,
+            blocks: [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": "Tiketistäsi on luotu uusi palvelupyyntö Ylen Service Deskiin",
+                  "emoji": false
+                }
+              },
+              {
+                "type": "divider"
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": res.number + ': *<' + tiksu_url + '|' + res.short_description + '>*'
+                }
+              },
+              {
+                "type": "section",
+                "fields": [
+                  {
+                    "type": "mrkdwn",
+                    "text": '*Järjestelmä tai tuotantoyksikkö:*\n' + res.u_app_or_prod_unit.display_value
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": '*Tiketti avattu:*\n' + res.opened_at
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": '*Komponentti:*\n' + res.cmdb_ci
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": '*Asiakas, jos tiedossa:*\n' + res.caller_id.display_value
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": '*Palvelujono:*\n' + res.assignment_group.display_value
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": '*Prioriteetti:*\n' + res.priority
+                  }
+                ]
+              },
+              {
+                "type": "divider"
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": res.description
+                }
+              }
+            ]
+          });
+        }
+        catch (error) {
+          console.error(error);
+          msg = 'Tiketin lähettäminen ei onnistunut.';
 
           try {
-            client.chat.postMessage({
+            await client.chat.postMessage({
               channel: user_id,
-              text: msg,
-              blocks: [
-                {
-                  "type": "header",
-                  "text": {
-                    "type": "plain_text",
-                    "text": "Tiketistäsi on luotu uusi palvelupyyntö Ylen Service Deskiin",
-                    "emoji": false
-                  }
-                },
-                {
-                  "type": "divider"
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": tiksu_response.number + ': *<' + tiksu_url + '|' + tiksu_response.short_description + '>*'
-                  }
-                },
-                {
-                  "type": "section",
-                  "fields": [
-                    {
-                      "type": "mrkdwn",
-                      "text": '*Järjestelmä tai tuotantoyksikkö:*\n' + tiksu_response.u_app_or_prod_unit.display_value
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": '*Tiketti avattu:*\n' + tiksu_response.opened_at
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": '*Komponentti:*\n' + tiksu_response.cmdb_ci
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": '*Asiakas, jos tiedossa:*\n' + tiksu_response.caller_id.display_value
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": '*Palvelujono:*\n' + tiksu_response.assignment_group.display_value
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": '*Prioriteetti:*\n' + tiksu_response.priority
-                    }
-                  ]
-                },
-                {
-                  "type": "divider"
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": tiksu_response.description
-                  }
-                }
-              ]
+              text: msg
             });
           }
           catch (error) {
             console.error(error);
           }
-
-        });
-      }
-      catch (error) {
-        console.error(error);
-        msg = 'Tiketin lähettäminen ei onnistunut.';
-
-        try {
-          client.chat.postMessage({
-            channel: user_id,
-            text: msg
-          });
         }
-        catch (error) {
-          console.error(error);
-        }
+
+
+      } catch (err) {
+          console.error(err);
       }
+
     }
+
+
 });
 
 // Handle the Lambda function event

--- a/serverless.yml
+++ b/serverless.yml
@@ -10,6 +10,9 @@ provider:
   environment:
     SLACK_SIGNING_SECRET: ${env:SLACK_SIGNING_SECRET_TIKSUTTELIJA}
     SLACK_BOT_TOKEN: ${env:SLACK_BOT_TOKEN_TIKSUTTELIJA}
+    TIKSU_INSTANCE: ${env:TIKSU_INSTANCE}
+    TIKSU_USERID: ${env:TIKSU_USERID}
+    TIKSU_PASSWORD: ${env:TIKSU_PASSWORD}
 functions:
   slack:
     handler: app.handler


### PR DESCRIPTION
This app has worked fine when deployed with `serverless offline`. However, when deployed to AWS using `serverless deploy`, function call to create a new incident in ServiceNow always failed. 

The error messages led me to believe that the problem lies in the internal function call that doesn't get access to the event object passed to the Lambda function when AWS API GW launches it.

After dissecting the ServiceNow wrapper library and rewriting it from callback to async/await, and still not getting nowhere, I tried to create a listener middleware that enriches the context object with those env parameters. That failed too, and after way too many hours of reading and messing up my code, I finally realized that the env definitions are completely missing from serverless.yml. I had wondered, why Slack related env variables work fine, but not ServiceNow's. Slack envs were defined correctly, as they were present in the previous app I was working with.
